### PR TITLE
build - get golang.org/x/tools/go/packages explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk --update add ca-certificates
 FROM golang:1.11.4-stretch as intermediate
 
 # Build dependencies
+RUN go get golang.org/x/tools/go/packages
+RUN go install golang.org/x/tools/go/packages
 RUN go get github.com/golang/mock/gomock
 RUN go install github.com/golang/mock/mockgen
 RUN go get github.com/golang/dep/cmd/dep


### PR DESCRIPTION
https://github.com/golang/mock/commit/79d8603a659da203b11a30b9faeb999604924d86
We need to install this dependency manually if we want to install `mockgen` manually:
```We'll just let modules take care of keeping track of the deps.```