### PR TITLE
itests - use docker cp instead of vol & split out signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN apk --update add ca-certificates
 # Test and build binary
 FROM golang:1.11.4-stretch as intermediate
 
+# Make a directory to place pprof files in. Typically used for itests.
+RUN mkdir /perf
+
 # Build dependencies
 RUN go get golang.org/x/tools/go/packages
 RUN go install golang.org/x/tools/go/packages
@@ -37,5 +40,6 @@ RUN make test && make build
 # Package binary & certs in a scratch container
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=intermediate /perf /perf
 COPY --from=intermediate /go/src/github.com/Nextdoor/pg-bifrost.git/target/pg-bifrost /
 CMD ["/pg-bifrost"]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ Messages from the same transaction go to the same shard (ordered) | transaction-
 Messages from the same table go to the same shard (unordered) | tablename | round-robin
 Messages from the same table go to the same shard (ordered) | tablename | partition
 
+### Profiling
+
+pg-bifrost natively supports CPU and memory profiling via `pprof`. To start profiling of either, you can simply specify the filesystem location of each expected `pprof` file via `CPUPROFILE` and `MEMPROFILE`.
+
+To end profiling, you send pg-bifrost a `SIGUSR1` signal and the `pprof` files will be finalized and closed.
+
+**NOTE:** Profiling can only be done one time for any single run of pg-bifrost. Once a `SIGUSR1` is sent, further signals will have no effect in finalizing profiling.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,23 @@ Messages from the same table go to the same shard (ordered) | tablename | partit
 
 pg-bifrost natively supports CPU and memory profiling via `pprof`. To start profiling of either, you can simply specify the filesystem location of each expected `pprof` file via `CPUPROFILE` and `MEMPROFILE`.
 
-To end profiling, you send pg-bifrost a `SIGUSR1` signal and the `pprof` files will be finalized and closed.
+**CPU Profiling**
 
-**NOTE:** Profiling can only be done one time for any single run of pg-bifrost. Once a `SIGUSR1` is sent, further signals will have no effect in finalizing profiling.
+To end CPU profiling, you send pg-bifrost a `SIGUSR1` signal and the `pprof` file will be finalized and written.
+
+*NOTE:* CPU profiling can only be done one time for any single run of pg-bifrost. Once a `SIGUSR1` is sent, further signals will have no effect in finalizing CPU profiling. A final CPU profile will also be written upon graceful shutdown of pg-bifrost, if it hasn't already been finalized.
+
+**Memory Profiling**
+
+To dump a memory profile, you send pg-bifrost a `SIGUSR2` signal and the `pprof` file will be written.
+
+*NOTE:* CPU profiling **can** be done multiple times for any single run of pg-bifrost. A final memory profile will also be written upon graceful shutdown of pg-bifrost.
+
+### Debugging
+
+**Progress Tracker (Ledger) Dump**
+
+In rare scenarios to investigate WAL standby acknowledgement issues to postgres (e.g., thrashing on duplicate data, a missing transaction, etc.) the ledger (the progress tracker's data structure to keep track of received and acknowledged transactions and their WAL messages) can be dumped to STDOUT by sending a `SIGIO` signal to pg-bifrost.
 
 ## Development
 

--- a/itests/common.bash
+++ b/itests/common.bash
@@ -169,7 +169,8 @@ _gather_test_output() {
 
   if [ -d "./tests/$BATS_TEST_DESCRIPTION/perf_base" ]; then
       log "Exporting performance test output from containers"
-      TEST_NAME=$BATS_TEST_DESCRIPTION docker-compose kill -s USR1 bifrost
+      TEST_NAME=$BATS_TEST_DESCRIPTION docker-compose kill -s USR1 bifrost # dump cpuprofile
+      TEST_NAME=$BATS_TEST_DESCRIPTION docker-compose kill -s USR2 bifrost # dump memprofile
       sleep 2
 
       docker cp bifrost:/perf ./tests/$BATS_TEST_DESCRIPTION/perf_output
@@ -255,7 +256,7 @@ teardown() {
   _end_timer
 
   # Print current state of the ledger for debugging
-  TEST_NAME=$BATS_TEST_DESCRIPTION docker-compose kill -s USR2 bifrost
+  TEST_NAME=$BATS_TEST_DESCRIPTION docker-compose kill -s IO bifrost # dump ledger to stdout
   sleep 5
   TEST_NAME=$BATS_TEST_DESCRIPTION docker-compose logs bifrost
 

--- a/itests/containers/data-poller/app/poller-kinesis.py
+++ b/itests/containers/data-poller/app/poller-kinesis.py
@@ -120,5 +120,6 @@ while total < EXPECTED_COUNT:
         time.sleep(1)
     sys.stdout.flush()
 
+# NOTE: 'Records read' is used by the tests framework to know when all expected data has been read.
 print("Records read {}".format(total))
 sys.stdout.flush()

--- a/itests/docker-compose.yml
+++ b/itests/docker-compose.yml
@@ -31,8 +31,6 @@ services:
       - "./containers/defaults.env"
       - "./tests/${TEST_NAME}/envfile.env"
       - "./contexts/${TRANSPORT_SINK}.env"
-    volumes:
-      - "./tests/${TEST_NAME}/perf_output:/perf"
     networks:
       net:
         aliases:
@@ -47,8 +45,6 @@ services:
       - "./containers/defaults.env"
       - "./tests/${TEST_NAME}/envfile.env"
       - "./contexts/${TRANSPORT_SINK}.env"
-    volumes:
-      - "./tests/${TEST_NAME}/output:/output"
     networks:
       net:
         aliases:

--- a/main/main.go
+++ b/main/main.go
@@ -265,6 +265,8 @@ func runReplicate(
 						memProfile(fmt.Sprintf(memprofile))
 					}
 
+					// bifrost only supports gathering of profiling data once. This flag will permanantly disable
+					// profiling in the existing runtime and further SIGUSR1 signals will not start/stop it again.
 					stoppedProfiling = true
 				}
 


### PR DESCRIPTION
This is better because files created in volumes by docker containers take the ownership permissions of the container's user/group (default `root`). This presents an issue when trying to clean-up those files from the host if that user isn't root (such as from CircleCI).