### PR TITLE
s3 - endpoint pointer - fix value check & override

### DIFF
--- a/transport/transporters/s3/transporter/transporter.go
+++ b/transport/transporters/s3/transporter/transporter.go
@@ -128,12 +128,10 @@ func NewTransporter(shutdownHandler shutdown.ShutdownHandler,
 	awsRegion *string,
 	awsAccessKeyId *string,
 	awsSecretAccessKey *string,
-	endpoint *string,) transport.Transporter {
+	endpointPtr *string,) transport.Transporter {
 
 	awsConfig := &aws.Config{
 		Region:      		aws.String(*awsRegion),
-		S3ForcePathStyle: 	aws.Bool(true),
-		Endpoint:    		aws.String(*endpoint),
 		MaxRetries:		aws.Int(0), // We disable the client retry policy because of our own retry logic
 	}
 
@@ -143,9 +141,9 @@ func NewTransporter(shutdownHandler shutdown.ShutdownHandler,
 		awsConfig.Credentials = credentials.NewStaticCredentials(*awsAccessKeyId, *awsSecretAccessKey, "")
 	}
 
-	if *endpoint != "" {
+	if endpointPtr != nil {
 		// If specifying a custom endpoint (such as for localstack) then configure that and use Path Style
-		awsConfig.Endpoint = aws.String(*endpoint)
+		awsConfig.Endpoint = aws.String(*endpointPtr)
 		awsConfig.S3ForcePathStyle = aws.Bool(true)
 	}
 


### PR DESCRIPTION
```
0 [nehal@Nehals-Nextdoor-MacBook-Pro target] (nehal/s3-fix-aws-endpoint-code) $ PGHOST=localhost   PGPASSWORD=pgbifrost   CREATE_SLOT=true   BIFROST_S3_BUCKET=nehal-bifrost-test-bucket   AWS_REGION=us-west-1   WORKERS=2   ./pg-bifro
st replicate --create-slot s3
INFO[0000] Attempting to create a connection to localhost on 5432  package=conn
Replication slot 'pg_bifrost' already exists.
INFO[0000] Replicating to s3                             package=app
INFO[0000] replicationSlot=pg_bifrost                    package=app
INFO[0000] clientBufferSize=10000                        package=app
INFO[0000] whitelist=false                               package=app
INFO[0000] tablelist=[]                                  package=app
INFO[0000] partMethod=0                                  package=app
INFO[0000] partPartitions=1                              package=app
INFO[0000] batchFlushUpdateAge=500                       package=app
INFO[0000] batchFlushMaxAge=1000                         package=app
INFO[0000] batchQueueDepth=2                             package=app
INFO[0000] batcherMemorySoftLimit=104857600              package=app
INFO[0000] batcherRoutingMethod=0                        package=app
INFO[0000] Starting                                      package=client
INFO[0000] Attempting to create a connection to localhost on 5432  package=conn
INFO[0000] starting                                      package=aggregator routine=reportAggregatesWorker
INFO[0000] starting batcher                              package=batcher
INFO[0000] starting                                      package=partitioner
INFO[0000] starting                                      package=aggregator routine=processStatsMessagesWorker
INFO[0000] starting transporter                          id=0 package=s3 routine=transporter
INFO[0000] starting transporter                          id=1 package=s3 routine=transporter
INFO[0000] starting                                      package=marshaller
INFO[0000] starting                                      package=progress_tracker
INFO[0000] starting                                      package=filter
INFO[0000] blacklist filter on tables []                 package=filter
INFO[0000] replication slot LSN: 0/14F1000 / 21958656    package=client
INFO[0005] sent progress LSN: 0/14F1000 / 21958656       package=client
INFO[0035] sent progress LSN: 0/14F1000 / 21958656       package=client
INFO[0061] successful PUT: nehal-bifrost-test-bucket/2019/05/13/20190513133854_22098568.gz  id=0 package=s3 routine=transporter
INFO[0069] sent progress LSN: 0/1513548 / 22099272       package=client
```