### PR TITLE
Fix race condition in rabbitmq transporter_test.go

### DIFF
--- a/transport/transporters/rabbitmq/transporter/transporter_test.go
+++ b/transport/transporters/rabbitmq/transporter/transporter_test.go
@@ -173,7 +173,7 @@ func TestConnectionDies(t *testing.T) {
 			wg.Done()
 			return amqptest.Dial(connString)
 		},
-	).Times(3)
+	).MinTimes(3)
 	mockConn, err := connMan.GetConnection(context.Background())
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
- GetConnection() will be called at least 3 times.  Once for the initial setup,
once for the failure, and once again after the mock server is available again.
But if there's a slowdown, the third call might be repeated until the server is
actually available.

@nehalrp Does this fix issue #33 for you?