### PR TITLE
s3 transporter - change key partitioning to YYYY/MM/DD/HH

### DIFF
--- a/transport/transporters/s3/transporter/transporter.go
+++ b/transport/transporters/s3/transporter/transporter.go
@@ -225,10 +225,10 @@ func (t *S3Transporter) transportWithRetry(ctx context.Context, messagesSlice []
 	byteArray = nil
 
 	// Partition the S3 keys into days
-	year, month, day, full := TimeSource.DateString()
+	year, month, day, hour, full := TimeSource.DateString()
 	baseFilename := fmt.Sprintf("%s_%d", full, firstWalStart)
 
-	fullKey := key_join(t.keySpace, year, month, day, baseFilename)
+	fullKey := key_join(t.keySpace, year, month, day, hour, baseFilename)
 
 	// An operation that may fail.
 	operation := func() error {

--- a/transport/transporters/s3/transporter/transporter_test.go
+++ b/transport/transporters/s3/transporter/transporter_test.go
@@ -157,14 +157,14 @@ func TestSinglePutOk(t *testing.T) {
 	// Expects
 	expectedInput := s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
-		Key: aws.String("2000/01/02/456_1234.gz"),
+		Key: aws.String("2000/01/02/03/456_1234.gz"),
 		Body: gzipAsReadSeeker(b.GetPayload().([]*marshaller.MarshalledMessage)),
 		ContentEncoding: aws.String("gzip"),
 	}
 
 	mockClient.EXPECT().PutObjectWithContext(sh.TerminateCtx, EqPutObjectInputWithBufferRead(&expectedInput)).Return(nil, nil)
 
-	mockTime.EXPECT().DateString().Return("2000", "01", "02", "456")
+	mockTime.EXPECT().DateString().Return("2000", "01", "02", "03", "456")
 
 	mockTime.EXPECT().UnixNano().Return(int64(0))
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))
@@ -234,14 +234,14 @@ func TestSinglePutMultipleRecordsOk(t *testing.T) {
 	// Expects
 	expectedInput := s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
-		Key: aws.String("2000/01/02/456_1234.gz"),
+		Key: aws.String("2000/01/02/03/456_1234.gz"),
 		Body: gzipAsReadSeeker(b.GetPayload().([]*marshaller.MarshalledMessage)),
 		ContentEncoding: aws.String("gzip"),
 	}
 
 	mockClient.EXPECT().PutObjectWithContext(sh.TerminateCtx, EqPutObjectInputWithBufferRead(&expectedInput)).Return(nil, nil)
 
-	mockTime.EXPECT().DateString().Return("2000", "01", "02", "456")
+	mockTime.EXPECT().DateString().Return("2000", "01", "02", "03", "456")
 
 	mockTime.EXPECT().UnixNano().Return(int64(0))
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))
@@ -301,7 +301,7 @@ func TestSingleRecordSinglePutWithFailuresNoError(t *testing.T) {
 	// Expects
 	expectedInputOne := s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
-		Key: aws.String("2000/01/02/456_1234.gz"),
+		Key: aws.String("2000/01/02/03/456_1234.gz"),
 		Body: gzipAsReadSeeker(b.GetPayload().([]*marshaller.MarshalledMessage)),
 		ContentEncoding: aws.String("gzip"),
 	}
@@ -309,7 +309,7 @@ func TestSingleRecordSinglePutWithFailuresNoError(t *testing.T) {
 	// We need two "identical" inputs because Body's io.Reader is mutable (reading again needs a Seek to rewind)
 	expectedInputTwo := s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
-		Key: aws.String("2000/01/02/456_1234.gz"),
+		Key: aws.String("2000/01/02/03/456_1234.gz"),
 		Body: gzipAsReadSeeker(b.GetPayload().([]*marshaller.MarshalledMessage)),
 		ContentEncoding: aws.String("gzip"),
 	}
@@ -317,7 +317,7 @@ func TestSingleRecordSinglePutWithFailuresNoError(t *testing.T) {
 	mockClient.EXPECT().PutObjectWithContext(sh.TerminateCtx, EqPutObjectInputWithBufferRead(&expectedInputOne)).Return(nil, errors.New("some error"))
 	mockClient.EXPECT().PutObjectWithContext(sh.TerminateCtx, EqPutObjectInputWithBufferRead(&expectedInputTwo)).Return(nil, nil)
 
-	mockTime.EXPECT().DateString().Return("2000", "01", "02", "456")
+	mockTime.EXPECT().DateString().Return("2000", "01", "02", "03", "456")
 
 	mockTime.EXPECT().UnixNano().Return(int64(0))
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))
@@ -379,7 +379,7 @@ func TestSingleRecordDoublePutRetriesExhaustedWithError(t *testing.T) {
 	// Expects
 	expectedInputOne := s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
-		Key: aws.String("2000/01/02/456_1234.gz"),
+		Key: aws.String("2000/01/02/03/456_1234.gz"),
 		Body: gzipAsReadSeeker(b.GetPayload().([]*marshaller.MarshalledMessage)),
 		ContentEncoding: aws.String("gzip"),
 	}
@@ -387,7 +387,7 @@ func TestSingleRecordDoublePutRetriesExhaustedWithError(t *testing.T) {
 	// We need two "identical" inputs because Body's io.Reader is mutable (reading needs a Seek back to start offset)
 	expectedInputTwo := s3.PutObjectInput{
 		Bucket: aws.String(bucketName),
-		Key: aws.String("2000/01/02/456_1234.gz"),
+		Key: aws.String("2000/01/02/03/456_1234.gz"),
 		Body: gzipAsReadSeeker(b.GetPayload().([]*marshaller.MarshalledMessage)),
 		ContentEncoding: aws.String("gzip"),
 	}
@@ -395,7 +395,7 @@ func TestSingleRecordDoublePutRetriesExhaustedWithError(t *testing.T) {
 	mockClient.EXPECT().PutObjectWithContext(sh.TerminateCtx, EqPutObjectInputWithBufferRead(&expectedInputOne)).Return(nil, errors.New("some error"))
 	mockClient.EXPECT().PutObjectWithContext(sh.TerminateCtx, EqPutObjectInputWithBufferRead(&expectedInputTwo)).Return(nil, errors.New("some error"))
 
-	mockTime.EXPECT().DateString().Return("2000", "01", "02", "456")
+	mockTime.EXPECT().DateString().Return("2000", "01", "02", "03", "456")
 
 	mockTime.EXPECT().UnixNano().Return(int64(0))
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))

--- a/utils/mocks/mock_timesource.go
+++ b/utils/mocks/mock_timesource.go
@@ -33,14 +33,15 @@ func (m *MockTimeSource) EXPECT() *MockTimeSourceMockRecorder {
 }
 
 // DateString mocks base method
-func (m *MockTimeSource) DateString() (string, string, string, string) {
+func (m *MockTimeSource) DateString() (string, string, string, string, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DateString")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
 	ret3, _ := ret[3].(string)
-	return ret0, ret1, ret2, ret3
+	ret4, _ := ret[4].(string)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // DateString indicates an expected call of DateString

--- a/utils/time.go
+++ b/utils/time.go
@@ -25,7 +25,7 @@ import (
 //go:generate mockgen -destination mocks/mock_timesource.go -package=mocks github.com/Nextdoor/pg-bifrost.git/utils TimeSource
 type TimeSource interface {
 	UnixNano() int64
-	DateString() (string, string, string, string)
+	DateString() (string, string, string, string, string)
 }
 
 type RealTime struct{}
@@ -44,14 +44,21 @@ func intDateToNormalString(i int) string {
 	return strconv.Itoa(i)
 }
 
-// DateString return year/month/day as seperate strings and also a normalized string of datetime that is 14 characters.
-// It is intended to be used to partition PUTs on transport sinks.
-func (rt RealTime) DateString() (year string, month string, day string, full string) {
+// DateString return year/month/day/hour as seperate strings and also a normalized string of datetime that is 14
+// characters. It is intended to be used to partition PUTs on transport sinks.
+func (rt RealTime) DateString() (
+	year string, month string, day string, hour string, full string) {
 	now := time.Now()
 	yearInt, timeMonth, dayInt := now.Date()
 	monthInt := int(timeMonth)
 
+	hourInt := now.Hour()
+
 	fullFormat := now.Format("20060102150405")
 
-	return strconv.Itoa(yearInt), intDateToNormalString(monthInt), intDateToNormalString(dayInt), fullFormat
+	return strconv.Itoa(yearInt),
+	       intDateToNormalString(monthInt),
+	       intDateToNormalString(dayInt),
+	       intDateToNormalString(hourInt),
+	       fullFormat
 }


### PR DESCRIPTION
The intention was for this to more closely follow the time partitioning of firehose.