### PR TITLE
replace built in json encoder with json-iterator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -168,6 +168,30 @@
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:beb5b4f42a25056f0aa291b5eadd21e2f2903a05d15dfe7caf7eaee7e12fa972"
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
+  version = "1.1.8"
+
+[[projects]]
+  digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
+
+[[projects]]
   digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"
   name = "github.com/pborman/uuid"
   packages = ["."]
@@ -276,6 +300,7 @@
     "github.com/golang/mock/gomock",
     "github.com/google/go-cmp/cmp",
     "github.com/jackc/pgx",
+    "github.com/json-iterator/go",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/streadway/amqp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -84,3 +84,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/NeowayLabs/wabbit"
+
+[[constraint]]
+  name = "github.com/json-iterator/go"
+  version = "1.1.8"

--- a/marshaller/marshaller.go
+++ b/marshaller/marshaller.go
@@ -17,14 +17,15 @@
 package marshaller
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
+
 	"os"
 	"time"
 
+	"github.com/Nextdoor/parselogical"
 	"github.com/Nextdoor/pg-bifrost.git/replication"
 	"github.com/Nextdoor/pg-bifrost.git/shutdown"
 	"github.com/Nextdoor/pg-bifrost.git/stats"
-	"github.com/Nextdoor/parselogical"
 	"github.com/jackc/pgx"
 	"github.com/sirupsen/logrus"
 )
@@ -32,6 +33,7 @@ import (
 var (
 	logger = logrus.New()
 	log    = logger.WithField("package", "marshaller")
+	json   = jsoniter.ConfigCompatibleWithStandardLibrary
 )
 
 func init() {
@@ -182,7 +184,7 @@ func marshalWalToJson(msg *replication.WalMessage) ([]byte, error) {
 	lsn := pgx.FormatLSN(msg.WalStart)
 
 	// ServerTime * 1,000,000 to convert from milliseconds to nanoseconds
-	time := time.Unix(0, int64(msg.ServerTime) * 1000000).Format(time.RFC3339)
+	time := time.Unix(0, int64(msg.ServerTime)*1000000).Format(time.RFC3339)
 	columns := make(map[string]map[string]map[string]string)
 
 	for k, v := range msg.Pr.Columns {


### PR DESCRIPTION
We're spending a lot of time doing json encoding and I'm hoping this will improve throughput.