### PR TITLE
Fix sleep timers to prevent needless backpressure

### DIFF
--- a/replication/client/client.go
+++ b/replication/client/client.go
@@ -424,12 +424,8 @@ func (c *Replicator) Start(progressChan <-chan uint64) {
 					}
 
 					// Sleep here to prevent spinning.
-					log.Infof("sleeping for %d", curSleep)
 					time.Sleep(curSleep)
 					curSleep = curSleep * 2
-
-
-					//time.Sleep(2 * time.Second)
 				}
 			}
 		}()

--- a/replication/client/client.go
+++ b/replication/client/client.go
@@ -424,8 +424,12 @@ func (c *Replicator) Start(progressChan <-chan uint64) {
 					}
 
 					// Sleep here to prevent spinning.
+					log.Infof("sleeping for %d", curSleep)
 					time.Sleep(curSleep)
 					curSleep = curSleep * 2
+
+
+					//time.Sleep(2 * time.Second)
 				}
 			}
 		}()

--- a/replication/client/client.go
+++ b/replication/client/client.go
@@ -36,6 +36,11 @@ var (
 	logger              = logrus.New()
 	log                 = logger.WithField("package", "client")
 	logProgressInterval = int64(30 * time.Second)
+
+	// Settings for exponential sleep time. This prevents spinning when
+	// there is a backlog.
+	initialSleep = 10 * time.Millisecond
+	maxSleep     = 2 * time.Second
 )
 
 func init() {
@@ -400,6 +405,8 @@ func (c *Replicator) Start(progressChan <-chan uint64) {
 		// Attempt to write to channel. If full then send a keepalive and attempt
 		// to write to channel again.
 		err = func() error {
+			var curSleep = initialSleep
+
 			for {
 				select {
 				case c.outputChan <- wal:
@@ -412,7 +419,13 @@ func (c *Replicator) Start(progressChan <-chan uint64) {
 						return err
 					}
 
-					time.Sleep(2 * time.Second)
+					if curSleep > maxSleep {
+						curSleep = initialSleep
+					}
+
+					// Sleep here to prevent spinning.
+					time.Sleep(curSleep)
+					curSleep = curSleep * 2
 				}
 			}
 		}()

--- a/replication/client/client_test.go
+++ b/replication/client/client_test.go
@@ -1041,7 +1041,7 @@ func TestDeadlineExceeded(t *testing.T) {
 	go replicator.Start(progChan)
 
 	// test
-	time.Sleep(40 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	replicator.shutdownHandler.CancelFunc()
 
 	select {
@@ -1331,7 +1331,7 @@ func TestSendKeepaliveChanFull(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		assert.Fail(t, "did not pass test in time")
 	case <-expectChan:
-		replicator.shutdownHandler.CancelFunc()
+		// pass
 	}
 
 	// Wait for shutdown
@@ -1461,8 +1461,4 @@ func TestOldOverallProgress(t *testing.T) {
 
 	// Wait for shutdown
 	waitForShutdown(t, mockManager, sh, stoppedChan)
-}
-
-func TestFoo(t *testing.T) {
-	time.Sleep(5 * time.Second)
 }

--- a/replication/client/client_test.go
+++ b/replication/client/client_test.go
@@ -690,7 +690,7 @@ func TestStartNilWalMessage(t *testing.T) {
 	mockConn.EXPECT().WaitForReplicationMessage(gomock.Any()).Return(nil, nil).Do(
 		func(_ interface{}) {
 			time.Sleep(time.Millisecond * 5)
-		}).MinTimes(4)
+		}).MinTimes(2)
 
 	go replicator.Start(progChan)
 

--- a/replication/client/client_test.go
+++ b/replication/client/client_test.go
@@ -1041,7 +1041,7 @@ func TestDeadlineExceeded(t *testing.T) {
 	go replicator.Start(progChan)
 
 	// test
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(40 * time.Millisecond)
 	replicator.shutdownHandler.CancelFunc()
 
 	select {
@@ -1331,7 +1331,7 @@ func TestSendKeepaliveChanFull(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		assert.Fail(t, "did not pass test in time")
 	case <-expectChan:
-		// pass
+		replicator.shutdownHandler.CancelFunc()
 	}
 
 	// Wait for shutdown
@@ -1461,4 +1461,8 @@ func TestOldOverallProgress(t *testing.T) {
 
 	// Wait for shutdown
 	waitForShutdown(t, mockManager, sh, stoppedChan)
+}
+
+func TestFoo(t *testing.T) {
+	time.Sleep(5 * time.Second)
 }

--- a/transport/progress/progress_tracker.go
+++ b/transport/progress/progress_tracker.go
@@ -42,8 +42,8 @@ const (
 
 	// Settings for exponential sleep time when there have been no seen or
 	// written transactions. This prevents a spinning.
-	initialSleep = 2 * time.Millisecond
-	maxSleep     = 5 * time.Second
+	initialSleep = 100 * time.Microsecond
+	maxSleep     = 50 * time.Millisecond
 )
 
 func init() {


### PR DESCRIPTION
I discovered that we were creating a lock step problem. Our progress tracker was too aggressive at sleeping when it found no work to be done and our replication client was too aggressive backing off when there was back pressure.

What happened was was transports would all try to report work done but be blocked waiting up to 60ms. This would ultimately backup the replication client which would sleep for 2 seconds. When it was unblocked, there wold be a flood of data and the process would repeat.