### PR TITLE
Fix replication client unit test

### DIFF
--- a/replication/client/client.go
+++ b/replication/client/client.go
@@ -46,7 +46,6 @@ func init() {
 type Replicator struct {
 	shutdownHandler shutdown.ShutdownHandler
 	connManager     conn.ManagerInterface
-	stopReplication <-chan struct{} // todo: remove this
 	statsChan       chan stats.Stat
 	progressChan    <-chan uint64
 

--- a/replication/client/client.go
+++ b/replication/client/client.go
@@ -40,7 +40,7 @@ var (
 
 func init() {
 	logger.SetOutput(os.Stdout)
-	logger.SetLevel(logrus.DebugLevel)
+	logger.SetLevel(logrus.InfoLevel)
 }
 
 type Replicator struct {

--- a/replication/client/client_test.go
+++ b/replication/client/client_test.go
@@ -1462,7 +1462,3 @@ func TestOldOverallProgress(t *testing.T) {
 	// Wait for shutdown
 	waitForShutdown(t, mockManager, sh, stoppedChan)
 }
-
-func TestSleep(t *testing.T) {
-	time.Sleep(5000 * time.Millisecond)
-}


### PR DESCRIPTION
The unit tests did not previously properly shutdown the replication client go routine. This caused tests to panic because the client would continue work and perform "unexpected" actions.