### PR TITLE
fix handling of regex cli options

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -392,12 +392,20 @@ func replicateAction(c *cli.Context) error {
 	} else if len(wl) != 0 {
 		whitelist = true
 		tablelist = wl
-	} else {
+		regex = false
+	} else if len(wlr) != 0 {
+		whitelist = true
+		tablelist = wlr
+		regex = true
+	} else if len(bl) != 0 {
 		whitelist = false
 		tablelist = bl
+		regex = false
+	} else if len(blr) != 0 {
+		whitelist = false
+		tablelist = blr
+		regex = true
 	}
-
-	regex = (len(wlr) != 0 || len(blr) != 0)
 
 	filterConfig := make(map[string]interface{}, 0)
 	filterConfig["whitelist"] = whitelist


### PR DESCRIPTION
This improves the handling of whitelist-regex and blacklist-regex options which was simply confusing.

Before, you'd need to do something like `--whitelist table1,table2 --whitelist-regex true`, which also wasn't documented.

This improves it so it functions as desired, so that it can be either `--whitelist table1,table2` or `--whitelist-regex table1,table2`.  And so on for the blacklist feature as well.