### PR TITLE
Support marshalling inferred updates of NULL values

### DIFF
--- a/app/config/headers.go
+++ b/app/config/headers.go
@@ -49,4 +49,5 @@ const (
 	VAR_NAME_PARTITION_METHOD          = "partition-method"
 	VAR_NAME_PARTITION_COUNT           = "partition-count"
 	VAR_NAME_NO_MARSHAL_OLD_VALUE      = "no-marshal-old-value"
+	VAR_NAME_INFER_UPDATED_NULLS       = "infer-updated-nulls"
 )

--- a/app/runner.go
+++ b/app/runner.go
@@ -112,6 +112,12 @@ func New(shutdownHandler shutdown.ShutdownHandler,
 	}
 	log.Info("noMarshalOldValue=", noMarshalOldValue)
 
+	inferUpdatedNulls, ok := marshallerConfig[config.VAR_NAME_INFER_UPDATED_NULLS].(bool)
+	if !ok {
+		log.Panic("Wrong type assertion")
+	}
+	log.Info("inferUpdatedNulls=", inferUpdatedNulls)
+
 	// Get partitioner configurations
 	partMethod, ok := partitionConfig[config.VAR_NAME_PARTITION_METHOD].(partitioner.PartitionMethod)
 	if !ok {
@@ -189,7 +195,8 @@ func New(shutdownHandler shutdown.ShutdownHandler,
 		shutdownHandler,
 		partitionerInstance.OutputChan,
 		statsChan,
-		noMarshalOldValue)
+		noMarshalOldValue,
+		inferUpdatedNulls)
 
 	transportManager := manager.New(
 		shutdownHandler,

--- a/main/main.go
+++ b/main/main.go
@@ -409,6 +409,7 @@ func replicateAction(c *cli.Context) error {
 	//
 	marshallerConfig := make(map[string]interface{}, 0)
 	marshallerConfig[config.VAR_NAME_NO_MARSHAL_OLD_VALUE] = c.GlobalBool(config.VAR_NAME_NO_MARSHAL_OLD_VALUE)
+	marshallerConfig[config.VAR_NAME_INFER_UPDATED_NULLS] = c.GlobalBool(config.VAR_NAME_INFER_UPDATED_NULLS)
 
 	//
 	// Validate, construct and create partitioner config from Flags
@@ -654,6 +655,11 @@ func main() {
 					Name:   config.VAR_NAME_NO_MARSHAL_OLD_VALUE,
 					Usage:  "Disable marshalling of the old value. This can help with performance by only writing the new values.",
 					EnvVar: "NO_MARSHAL_OLD_VALUE",
+				},
+				cli.BoolFlag{
+					Name:   config.VAR_NAME_INFER_UPDATED_NULLS,
+					Usage:  "Enable inferring previous NULL values while marshalling updates.",
+					EnvVar: "INFER_UPDATED_NULLS",
 				},
 			},
 			Subcommands: []cli.Command{

--- a/marshaller/marshaller.go
+++ b/marshaller/marshaller.go
@@ -50,17 +50,19 @@ type Marshaller struct {
 	statsChan chan stats.Stat
 
 	noMarshalOldValue bool
+	inferUpdatedNulls bool
 }
 
 // New is a simple constructor which create a marshaller.
 func New(shutdownHandler shutdown.ShutdownHandler,
 	inputChan <-chan *replication.WalMessage,
 	statsChan chan stats.Stat,
-	noMarshalOldValue bool) Marshaller {
+	noMarshalOldValue bool,
+	inferUpdatedNulls bool) Marshaller {
 
 	outputChan := make(chan *MarshalledMessage)
 
-	return Marshaller{shutdownHandler, inputChan, outputChan, statsChan, noMarshalOldValue}
+	return Marshaller{shutdownHandler, inputChan, outputChan, statsChan, noMarshalOldValue, inferUpdatedNulls}
 }
 
 // jsonWalEntry is a helper struct which has json field tags
@@ -121,7 +123,7 @@ func (m Marshaller) Start() {
 			return
 		}
 
-		byteMessage, err := marshalWalToJson(walMessage, m.noMarshalOldValue)
+		byteMessage, err := marshalWalToJson(walMessage, m.noMarshalOldValue, m.inferUpdatedNulls)
 
 		if err != nil {
 			m.statsChan <- stats.NewStatCount("marshaller", "failure", 1, time.Now().UnixNano())
@@ -183,7 +185,7 @@ func marshalColumnValuePair(newValue *parselogical.ColumnValue, oldValue *parsel
 }
 
 // marshalWalToJson marshals a WalMessage using parselogical to parse the columns and returns a byte slice
-func marshalWalToJson(msg *replication.WalMessage, noMarshalOldValue bool) ([]byte, error) {
+func marshalWalToJson(msg *replication.WalMessage, noMarshalOldValue bool, inferUpdatedNulls bool) ([]byte, error) {
 	lsn := pglogrepl.LSN(msg.WalStart).String()
 
 	// ServerTime * 1,000,000 to convert from milliseconds to nanoseconds
@@ -214,6 +216,19 @@ func marshalWalToJson(msg *replication.WalMessage, noMarshalOldValue bool) ([]by
 			} else {
 				columns[k] = marshalColumnValuePair(&v, &oldV)
 			}
+		} else if inferUpdatedNulls && !noMarshalOldValue && !ok && msg.Pr.Operation == "UPDATE" {
+			// The test_decoding output omits NULL values from the old-key.
+			//
+			// Ordinarily the "old" key being omitted from the value pair represents an unchanged column, which
+			// consequently means that downstream consumers cannot differentiate between an unchanged column and
+			// an update from NULL to not NULL.
+
+			// Construct a NULL value when the column is missing from OldColumns
+			columns[k] = marshalColumnValuePair(&v, &parselogical.ColumnValue{
+				Value:  "null",
+				Type:   v.Type,
+				Quoted: false,
+			})
 		} else {
 			columns[k] = marshalColumnValuePair(&v, nil)
 		}

--- a/marshaller/marshaller.go
+++ b/marshaller/marshaller.go
@@ -200,7 +200,7 @@ func marshalWalToJson(msg *replication.WalMessage, noMarshalOldValue bool) ([]by
 
 		if ok && v.Value != oldV.Value {
 			// When column is TOAST-ed use the previous value instead of "unchanged-toast-datum"
-			if v.Value == "unchanged-toast-datum" {
+			if !v.Quoted && v.Value == "unchanged-toast-datum" {
 				if noMarshalOldValue {
 					columns[k] = marshalColumnValuePair(&oldV, nil)
 				} else {

--- a/marshaller/marshaller_test.go
+++ b/marshaller/marshaller_test.go
@@ -257,7 +257,7 @@ func TestToastValue(t *testing.T) {
 	toast := parselogical.ColumnValue{
 		Value:  "unchanged-toast-datum",
 		Type:   "string",
-		Quoted: true,
+		Quoted: false,
 	}
 
 	bm.Pr.Columns["first_name"] = toast
@@ -302,7 +302,7 @@ func TestToastNoOldValue(t *testing.T) {
 	toast := parselogical.ColumnValue{
 		Value:  "unchanged-toast-datum",
 		Type:   "string",
-		Quoted: true,
+		Quoted: false,
 	}
 
 	bm.Pr.Columns["first_name"] = toast


### PR DESCRIPTION
Within an `UPDATE` operation, downstream consumers currently cannot differentiate between an unchanged column and an update from `NULL` to not `NULL` . This is of course only relevant for tables that have set `REPLICA IDENTITY FULL`.

This is due to an interaction quirk that arises from the following details:
* The test_decoding output omits `NULL` values from `old-key`.
* The `old` key being omitted from the published output represents an unchanged column.

This PR attempts to address this by adding a new `infer-updated-nulls` setting, which causes the marshaller to inject a `NULL` value for each column  missing from the decoded `old-key`.