### PR TITLE
main/main.go: use log.Printf instead of fmt.Printf

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -164,7 +164,7 @@ func runCreate(sourceConfig *pgconn.Config, replicationSlot string) error {
 		}
 	}
 
-	fmt.Printf("Created replication slot '%s'\n", replicationSlot)
+	log.Infof("Created replication slot '%s'", replicationSlot)
 	return nil
 }
 
@@ -177,7 +177,7 @@ func runDrop(sourceConfig *pgconn.Config, replicationSlot string) error {
 		return err
 	}
 
-	fmt.Printf("Dropped replication slot '%s'\n", replicationSlot)
+	log.Infof("Dropped replication slot '%s'", replicationSlot)
 	return nil
 }
 

--- a/replication/client/conn/conn.go
+++ b/replication/client/conn/conn.go
@@ -42,7 +42,7 @@ func New(ctx context.Context, conf *pgconn.Config) (Conn, error) {
 	return conn, err
 }
 
-// getConnWithRetry wraps New with a retry loop. It returns a
+// NewConnWithRetry wraps New with a retry loop. It returns a
 // new replication connection without starting replication.
 func NewConnWithRetry(ctx context.Context, sourceConfig *pgconn.Config) (Conn, error) {
 	var conn Conn
@@ -84,7 +84,7 @@ func (c PgReplConnWrapper) SendStandbyStatus(ctx context.Context, status pglogre
 	return pglogrepl.SendStandbyStatusUpdate(ctx, c.conn, status)
 }
 
-// WaitForReplicationMessage wraps pgconn.PgConn.ReceiveMessage
+// ReceiveMessage wraps pgconn.PgConn.ReceiveMessage
 func (c PgReplConnWrapper) ReceiveMessage(ctx context.Context) (pgproto3.BackendMessage, error) {
 	return c.conn.ReceiveMessage(ctx)
 }


### PR DESCRIPTION
I think we should use `log` as much as possible, consistently throughout the code base.