### PR TITLE
main/main.go: fix a TODO related to better error handling

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -153,9 +153,9 @@ func sourceConfig(c *cli.Context) *pgconn.Config {
 func runCreate(sourceConfig *pgconn.Config, replicationSlot string) error {
 	err := utils.PgCreateReplicationSlot(context.Background(), sourceConfig, replicationSlot)
 
-	// TODO proper error handling
 	if err != nil {
-		if strings.HasSuffix(err.Error(), "(SQLSTATE 42710)") {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42710" {
 			fmt.Printf("Replication slot '%s' already exists.\n", replicationSlot)
 			return nil
 		} else {

--- a/replication/client/conn/conn.go
+++ b/replication/client/conn/conn.go
@@ -42,7 +42,7 @@ func New(ctx context.Context, conf *pgconn.Config) (Conn, error) {
 	return conn, err
 }
 
-// getConnWithRetry wraps New with a retry loop. It returns a
+// NewConnWithRetry wraps New with a retry loop. It returns a
 // new replication connection without starting replication.
 func NewConnWithRetry(ctx context.Context, sourceConfig *pgconn.Config) (Conn, error) {
 	var conn Conn
@@ -84,7 +84,7 @@ func (c PgReplConnWrapper) SendStandbyStatus(ctx context.Context, status pglogre
 	return pglogrepl.SendStandbyStatusUpdate(ctx, c.conn, status)
 }
 
-// WaitForReplicationMessage wraps pgconn.PgConn.ReceiveMessage
+// ReceiveMessage wraps pgconn.PgConn.ReceiveMessage
 func (c PgReplConnWrapper) ReceiveMessage(ctx context.Context) (pgproto3.BackendMessage, error) {
 	return c.conn.ReceiveMessage(ctx)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"hash/crc32"
 
@@ -25,8 +26,6 @@ import (
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pkg/errors"
-
-	"context"
 )
 
 // QuickHash buckets the string into i buckets based on crc32 hashing
@@ -50,7 +49,7 @@ func PgCreateReplicationSlot(ctx context.Context, sourceConfig *pgconn.Config, s
 
 	_, err = rplConn.CreateReplicationSlot(ctx, slot, "test_decoding", pglogrepl.CreateReplicationSlotOptions{Temporary: false})
 	if err != nil {
-		return errors.Wrapf(err, "unable to create slot %s", slot)
+		return fmt.Errorf("unable to create slot %s: %w", slot, err)
 	}
 
 	return err


### PR DESCRIPTION
Now that Go supports wrapping error natively, let's use it