### PR TITLE
New env flag to route DD metrics to the dd agent on the host

### DIFF
--- a/app/config/headers.go
+++ b/app/config/headers.go
@@ -18,17 +18,19 @@ package config
 
 // Global cli flag names
 const (
-	VAR_NAME_CONFIG      = "config"
-	VAR_NAME_SLOT        = "slot"
-	VAR_NAME_USER        = "user"
-	VAR_NAME_PASSWD      = "password"
-	VAR_NAME_HOST        = "host"
-	VAR_NAME_PORT        = "port"
-	VAR_NAME_DB          = "dbname"
-	VAR_NAME_MEM_PROFILE = "memprofile"
-	VAR_NAME_CPU_PROFILE = "cpuprofile"
-	VAR_NAME_DD_HOST     = "datadog-host"
-	VAR_NAME_DD_TAGS     = "datadog-tags"
+	VAR_NAME_CONFIG        = "config"
+	VAR_NAME_SLOT          = "slot"
+	VAR_NAME_USER          = "user"
+	VAR_NAME_PASSWD        = "password"
+	VAR_NAME_HOST          = "host"
+	VAR_NAME_PORT          = "port"
+	VAR_NAME_DB            = "dbname"
+	VAR_NAME_MEM_PROFILE   = "memprofile"
+	VAR_NAME_CPU_PROFILE   = "cpuprofile"
+	VAR_NAME_DD_HOST       = "datadog-host"
+	VAR_NAME_DD_AGENT_HOST = "datadog-agent-host"
+	VAR_NAME_DD_AGENT_PORT = "datadog-agent-port"
+	VAR_NAME_DD_TAGS       = "datadog-tags"
 )
 
 // Replicate cli flag names

--- a/main/main.go
+++ b/main/main.go
@@ -127,10 +127,10 @@ var (
 				"' if it is provided or found in the env",
 			EnvVar: "DATADOG_AGENT_HOST",
 		}),
-		altsrc.NewStringFlag(cli.StringFlag{
+		altsrc.NewIntFlag(cli.IntFlag{
 			Name:   config.VAR_NAME_DD_AGENT_PORT,
 			Usage:  "datadog statsd agent port",
-			Value:  "8125",
+			Value:  8125,
 			EnvVar: "DATADOG_AGENT_PORT",
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
@@ -354,7 +354,6 @@ func getFlagValue(flagGeneric interface{}) interface{} {
 }
 
 func replicateAction(c *cli.Context) error {
-	fmt.Printf("Hello from replicatoin action")
 	if c.GlobalBool(config.VAR_NAME_CREATE_SLOT) {
 		err := runCreate(sourceConfig(c), c.GlobalString(config.VAR_NAME_SLOT))
 		if err != nil {
@@ -477,7 +476,7 @@ func replicateAction(c *cli.Context) error {
 
 	if c.GlobalString(config.VAR_NAME_DD_AGENT_HOST) != "" {
 		datadogAddr = fmt.Sprintf(
-			"%s:%s", c.GlobalString(config.VAR_NAME_DD_AGENT_HOST), c.GlobalString(config.VAR_NAME_DD_AGENT_PORT),
+			"%s:%d", c.GlobalString(config.VAR_NAME_DD_AGENT_HOST), c.GlobalInt(config.VAR_NAME_DD_AGENT_PORT),
 		)
 	} else {
 		datadogAddr = c.GlobalString(config.VAR_NAME_DD_HOST)

--- a/main/main.go
+++ b/main/main.go
@@ -129,7 +129,7 @@ var (
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:   config.VAR_NAME_DD_AGENT_PORT,
-			Usage:  "datadog agent port",
+			Usage:  "datadog statsd agent port",
 			Value:  "8125",
 			EnvVar: "DATADOG_AGENT_PORT",
 		}),

--- a/main/main.go
+++ b/main/main.go
@@ -122,6 +122,18 @@ var (
 			EnvVar: "DATADOG_HOST",
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
+			Name: config.VAR_NAME_DD_AGENT_HOST,
+			Usage: "datadog statsd agent hostname. This value takes precedence over '" + config.VAR_NAME_DD_HOST +
+				"' if it is provided or found in the env",
+			EnvVar: "DATADOG_AGENT_HOST",
+		}),
+		altsrc.NewStringFlag(cli.StringFlag{
+			Name:   config.VAR_NAME_DD_AGENT_PORT,
+			Usage:  "datadog agent port",
+			Value:  "8125",
+			EnvVar: "DATADOG_AGENT_PORT",
+		}),
+		altsrc.NewStringFlag(cli.StringFlag{
 			Name: config.VAR_NAME_DD_TAGS,
 			Usage: "datadog tags to add to emitted metrics. These are specified as key:value and are " +
 				"delimited by ','. For example key1:value1,key2:value2",
@@ -342,6 +354,7 @@ func getFlagValue(flagGeneric interface{}) interface{} {
 }
 
 func replicateAction(c *cli.Context) error {
+	fmt.Printf("Hello from replicatoin action")
 	if c.GlobalBool(config.VAR_NAME_CREATE_SLOT) {
 		err := runCreate(sourceConfig(c), c.GlobalString(config.VAR_NAME_SLOT))
 		if err != nil {
@@ -460,12 +473,21 @@ func replicateAction(c *cli.Context) error {
 	//
 	// Validate and create reporter config from Flags
 	//
-	datadogHost := c.GlobalString(config.VAR_NAME_DD_HOST)
+	var datadogAddr string
+
+	if c.GlobalString(config.VAR_NAME_DD_AGENT_HOST) != "" {
+		datadogAddr = fmt.Sprintf(
+			"%s:%s", c.GlobalString(config.VAR_NAME_DD_AGENT_HOST), c.GlobalString(config.VAR_NAME_DD_AGENT_PORT),
+		)
+	} else {
+		datadogAddr = c.GlobalString(config.VAR_NAME_DD_HOST)
+	}
+
 	datadogTags := c.GlobalString(config.VAR_NAME_DD_TAGS)
 	datadogTagsList := strings.Split(datadogTags, ",")
 
 	reporterConfig := make(map[string]interface{}, 0)
-	reporterConfig[config.VAR_NAME_DD_HOST] = datadogHost
+	reporterConfig[config.VAR_NAME_DD_HOST] = datadogAddr
 	reporterConfig[config.VAR_NAME_DD_TAGS] = datadogTagsList
 
 	//


### PR DESCRIPTION
Currently there is no way for pg-bifrost to pick up injected env variables for the dd host name. This specific use case comes up when working within a k8s environment where a datadog-operator injects an env variable that includes the host name information. 

This PR creates a new flag that pulls the dd host name from `DATADOG_AGENT_HOST` env var and the port from the `DATADOG_AGENT_PORT` env var (default value of the port is set to `8125`). These two values together are used to create the address of the dd agent. If the `DATADOG_AGENT_HOST` env _isn't_ populated, the service falls back on using the `DATADOG_HOST` as the address.

This change is backwards compatible with previous version. If it makes sense to do so, I can break backwards compatibility to have a cleaner implementation.