### PR TITLE
Correct Datadog agent host env var name

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -125,7 +125,7 @@ var (
 			Name: config.VAR_NAME_DD_AGENT_HOST,
 			Usage: "datadog statsd agent hostname. This value takes precedence over '" + config.VAR_NAME_DD_HOST +
 				"' if it is provided or found in the env",
-			EnvVar: "DATADOG_AGENT_HOST",
+			EnvVar: "DD_AGENT_HOST",
 		}),
 		altsrc.NewIntFlag(cli.IntFlag{
 			Name:   config.VAR_NAME_DD_AGENT_PORT,


### PR DESCRIPTION
Upon further inspection of the injected variable name into the container by the datadog-operator, the correct env var name to use is `DD_AGENT_HOST` and NOT `DATADOG_AGENT_HOST`.

This PR introduces a breaking change to fix forward.