### PR TITLE
add metrics around blocking for tuning

### DIFF
--- a/transport/batch/generic_batch.go
+++ b/transport/batch/generic_batch.go
@@ -16,8 +16,9 @@ type GenericBatch struct {
 	messages     []*marshaller.MarshalledMessage
 	transactions *ordered_map.OrderedMap
 	byteSize     int64
-	mtime        int64
-	ctime        int64
+	mtime        int64 // last modified
+	ctime        int64 // created
+	dtime        int64 // closed
 	partitionKey string
 }
 
@@ -25,7 +26,7 @@ func NewGenericBatch(partitionKey string, maxSize int) transport.Batch {
 	messages := []*marshaller.MarshalledMessage{}
 	transactions := ordered_map.NewOrderedMap()
 
-	return &GenericBatch{maxSize, messages, transactions, 0, time.Now().UnixNano(), time.Now().UnixNano(), partitionKey}
+	return &GenericBatch{maxSize, messages, transactions, 0, time.Now().UnixNano(), time.Now().UnixNano(), 0, partitionKey}
 }
 
 func (b *GenericBatch) Add(msg *marshaller.MarshalledMessage) (bool, error) {
@@ -57,6 +58,7 @@ func (b *GenericBatch) GetTransactions() *ordered_map.OrderedMap {
 
 func (b *GenericBatch) Close() (bool, error) {
 	// Nothing special required
+	b.dtime = time.Now().UnixNano()
 	return true, nil
 }
 
@@ -90,6 +92,10 @@ func (b *GenericBatch) ModifyTime() int64 {
 
 func (b *GenericBatch) CreateTime() int64 {
 	return b.ctime
+}
+
+func (b *GenericBatch) CloseTime() int64 {
+	return b.dtime
 }
 
 type GenericBatchFactory struct {

--- a/transport/batcher/batcher.go
+++ b/transport/batcher/batcher.go
@@ -391,10 +391,13 @@ func (b *Batcher) sendBatch(batch transport.Batch) bool {
 	}
 
 	log.Debugf("sending batch to worker %d", channelIndex)
+	start := time.Now()
 	b.outputChans[channelIndex] <- batch
+	now := time.Now()
 
-	b.statsChan <- stats.NewStatCount("batcher", "batches", 1, time.Now().UnixNano())
-	b.statsChan <- stats.NewStatHistogram("batcher", "batch_size", int64(batch.NumMessages()), time.Now().UnixNano(), "count")
+	b.statsChan <- stats.NewStatHistogram("batcher", "batch_write_wait", 1, now.Sub(start).Milliseconds(), "ms")
+	b.statsChan <- stats.NewStatCount("batcher", "batches", 1, now.UnixNano())
+	b.statsChan <- stats.NewStatHistogram("batcher", "batch_size", int64(batch.NumMessages()), now.UnixNano(), "count")
 
 	return true
 }

--- a/transport/batcher/batcher_test.go
+++ b/transport/batcher/batcher_test.go
@@ -102,6 +102,7 @@ func TestBatchSizeOneOneTxnOneData(t *testing.T) {
 
 	// Verify stats
 	expected := []stats.Stat{
+		stats.NewStatHistogram("batcher", "batch_write_wait", 1, time.Now().UnixNano(), "ms"),
 		stats.NewStatCount("batcher", "batches", 1, time.Now().UnixNano()),
 		stats.NewStatHistogram("batcher", "batch_size", 1, time.Now().UnixNano(), "count"),
 	}
@@ -369,8 +370,10 @@ func TestBatchSizeThreeTwoTxnTwoData(t *testing.T) {
 
 	// Verify stats
 	expectedStats := []stats.Stat{
+		stats.NewStatHistogram("batcher", "batch_write_wait", 1, time.Now().UnixNano(), "ms"),
 		stats.NewStatCount("batcher", "batches", 1, time.Now().UnixNano()),
 		stats.NewStatHistogram("batcher", "batch_size", 3, time.Now().UnixNano(), "count"),
+		stats.NewStatHistogram("batcher", "batch_write_wait", 1, time.Now().UnixNano(), "ms"),
 		stats.NewStatCount("batcher", "batches", 1, time.Now().UnixNano()),
 		stats.NewStatHistogram("batcher", "batch_size", 1, time.Now().UnixNano(), "count"),
 		stats.NewStatCount("batcher", "batch_closed_early", 1, time.Now().UnixNano()),

--- a/transport/transporters/s3/transporter/transporter_test.go
+++ b/transport/transporters/s3/transporter/transporter_test.go
@@ -168,8 +168,6 @@ func TestSinglePutOk(t *testing.T) {
 	mockTime.EXPECT().UnixNano().Return(int64(0))
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))
 	mockTime.EXPECT().UnixNano().Return(int64(2000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(3000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(4000 * time.Millisecond))
 
 	in <- b
 
@@ -183,7 +181,8 @@ func TestSinglePutOk(t *testing.T) {
 	expected := []stats.Stat{
 		stats.NewStatCount("s3_transport", "success", int64(1), int64(1000*time.Millisecond)),
 		stats.NewStatHistogram("s3_transport", "duration", 2000, int64(3000*time.Millisecond), "ms"),
-		stats.NewStatCount("s3_transport", "written", int64(1), int64(4000*time.Millisecond)),
+		stats.NewStatCount("s3_transport", "written", int64(1), int64(2000*time.Millisecond)),
+		stats.NewStatHistogram("s3_transport", "batch_waited", 2000, int64(2000*time.Millisecond), "ms"),
 	}
 	stats.VerifyStats(t, statsChan, expected)
 }
@@ -243,8 +242,6 @@ func TestSinglePutMultipleRecordsOk(t *testing.T) {
 	mockTime.EXPECT().UnixNano().Return(int64(0))
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))
 	mockTime.EXPECT().UnixNano().Return(int64(2000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(3000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(4000 * time.Millisecond))
 
 	in <- b
 
@@ -257,8 +254,9 @@ func TestSinglePutMultipleRecordsOk(t *testing.T) {
 	// Verify stats
 	expected := []stats.Stat{
 		stats.NewStatCount("s3_transport", "success", int64(1), int64(1000*time.Millisecond)),
-		stats.NewStatHistogram("s3_transport", "duration", 2000, int64(3000*time.Millisecond), "ms"),
-		stats.NewStatCount("s3_transport", "written", int64(2), int64(4000*time.Millisecond)),
+		stats.NewStatHistogram("s3_transport", "duration", 2000, int64(2000*time.Millisecond), "ms"),
+		stats.NewStatCount("s3_transport", "written", int64(2), int64(2000*time.Millisecond)),
+		stats.NewStatHistogram("s3_transport", "batch_waited", 2000, int64(2000*time.Millisecond), "ms"),
 	}
 	stats.VerifyStats(t, statsChan, expected)
 }
@@ -319,8 +317,6 @@ func TestSingleRecordSinglePutWithFailuresNoError(t *testing.T) {
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))
 	mockTime.EXPECT().UnixNano().Return(int64(2000 * time.Millisecond))
 	mockTime.EXPECT().UnixNano().Return(int64(3000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(4000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(5000 * time.Millisecond))
 
 	in <- b
 
@@ -334,8 +330,9 @@ func TestSingleRecordSinglePutWithFailuresNoError(t *testing.T) {
 	expected := []stats.Stat{
 		stats.NewStatCount("s3_transport", "failure", int64(1), int64(1000*time.Millisecond)),
 		stats.NewStatCount("s3_transport", "success", int64(1), int64(2000*time.Millisecond)),
-		stats.NewStatHistogram("s3_transport", "duration", 3000, int64(4000*time.Millisecond), "ms"),
-		stats.NewStatCount("s3_transport", "written", int64(1), int64(5000*time.Millisecond)),
+		stats.NewStatHistogram("s3_transport", "duration", 3000, int64(3000*time.Millisecond), "ms"),
+		stats.NewStatCount("s3_transport", "written", int64(1), int64(3000*time.Millisecond)),
+		stats.NewStatHistogram("s3_transport", "batch_waited", 3000, int64(3000*time.Millisecond), "ms"),
 	}
 	stats.VerifyStats(t, statsChan, expected)
 }
@@ -395,9 +392,7 @@ func TestSingleRecordDoublePutRetriesExhaustedWithError(t *testing.T) {
 	mockTime.EXPECT().UnixNano().Return(int64(0))
 	mockTime.EXPECT().UnixNano().Return(int64(1000 * time.Millisecond))
 	mockTime.EXPECT().UnixNano().Return(int64(2000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(3000 * time.Millisecond))
-	mockTime.EXPECT().UnixNano().Return(int64(4000 * time.Millisecond))
-
+	mockTime.EXPECT().UnixNano().Return(int64(2000 * time.Millisecond))
 	in <- b
 
 	// Start test
@@ -410,7 +405,7 @@ func TestSingleRecordDoublePutRetriesExhaustedWithError(t *testing.T) {
 	expected := []stats.Stat{
 		stats.NewStatCount("s3_transport", "failure", int64(1), int64(1000*time.Millisecond)),
 		stats.NewStatCount("s3_transport", "failure", int64(1), int64(2000*time.Millisecond)),
-		stats.NewStatHistogram("s3_transport", "duration", 3000, int64(4000*time.Millisecond), "ms"),
+		stats.NewStatHistogram("s3_transport", "duration", 2000, int64(2000*time.Millisecond), "ms"),
 	}
 	stats.VerifyStats(t, statsChan, expected)
 


### PR DESCRIPTION
I've been investigating a performance difference between 1.5.0 and subsequent releases. I have a theory this has to do with memory allocations changing performance characteristics very slightly which lead to blocking and a backoff throttle being applied when workers are unable to keep up.