### PR TITLE
decrease memory allocations

### DIFF
--- a/marshaller/marshaller_test.go
+++ b/marshaller/marshaller_test.go
@@ -442,3 +442,11 @@ func TestTerminationContextOutput(t *testing.T) {
 		assert.Fail(t, "output channel not properly closed")
 	}
 }
+
+func BenchmarkMarshalWalToJson(b *testing.B) {
+	msg := _basicInsertMessage()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = marshalWalToJson(msg, true)
+	}
+}

--- a/stats/aggregator/aggregator.go
+++ b/stats/aggregator/aggregator.go
@@ -277,8 +277,10 @@ func computeAggregateKey(s stats.Stat) string {
 // isBtimeExpired returns true if the current time is past the bucket time with a grace period
 func (a *Aggregator) isBtimeExpired(bucketTime int64) bool {
 	timeNow := a.timeNow().UnixNano()
-	log.Debugf(`%s > %s ?`, strconv.FormatInt(timeNow, 10),
-		strconv.FormatInt(bucketTime+a.aggregateTimeNano+reportGraceNano, 10))
+	if log.Level == logrus.DebugLevel {
+		log.Debugf(`%s > %s ?`, strconv.FormatInt(timeNow, 10),
+			strconv.FormatInt(bucketTime+a.aggregateTimeNano+reportGraceNano, 10))
+	}
 	return timeNow > bucketTime+a.aggregateTimeNano+reportGraceNano
 }
 


### PR DESCRIPTION
This PR decreases the number of memory allocations bifrost does by:
1.  re-using maps allocated during the marshaling processes. Note, for now I'm using `sync.Pool` which isn't super efficient and overkill for a single threaded usecase but it's quick dirty and keeps the code fairly clean.
2. adds a constant for formatted server time if the time is the epoch. Note, in practice we haven't seen this value ever be non-zero so I'm not sure if this is a library issue or if postgres never implemented this functionality.
3. I noticed the stats aggregator had a very expensive debug log call where we were formatting numbers prior to passing them to the logger. I'm a bit dubious of why we did it this way but for now I'm just wrapping the log line in a log level check.