### PR TITLE
don't marshall begin or commit messages

### DIFF
--- a/marshaller/marshaller_test.go
+++ b/marshaller/marshaller_test.go
@@ -437,7 +437,7 @@ func TestTerminationContextOutput(t *testing.T) {
 	m.shutdownHandler.CancelFunc()
 
 	time.Sleep(10 * time.Millisecond)
-	_, _ = <-m.OutputChan   // first message
+	<-m.OutputChan          // first message
 	_, ok := <-m.OutputChan // now channel is empty
 	if ok {
 		assert.Fail(t, "output channel not properly closed")

--- a/marshaller/marshaller_test.go
+++ b/marshaller/marshaller_test.go
@@ -437,7 +437,8 @@ func TestTerminationContextOutput(t *testing.T) {
 	m.shutdownHandler.CancelFunc()
 
 	time.Sleep(10 * time.Millisecond)
-	_, ok := <-m.OutputChan
+	_, _ = <-m.OutputChan   // first message
+	_, ok := <-m.OutputChan // now channel is empty
 	if ok {
 		assert.Fail(t, "output channel not properly closed")
 	}


### PR DESCRIPTION
The marshaller is doing unnecessary work processing these messages and they get discarded by the batcher because begin/commit messages are not passed downstream. 