### PR TITLE
send seen progress in batches

### DIFF
--- a/app/runner.go
+++ b/app/runner.go
@@ -171,7 +171,7 @@ func New(shutdownHandler shutdown.ShutdownHandler,
 	statsChan := make(chan stats.Stat, clientBufferSize*5)
 
 	// Transactions channels for progress reporting to the progress tracker
-	txnsSeen := make(chan *progress.Seen) // Must be unbuffered to maintain seen -> written ordering
+	txnsSeen := make(chan []*progress.Seen) // Must be unbuffered to maintain seen -> written ordering
 	txnsWritten := make(chan *ordered_map.OrderedMap, clientBufferSize*5)
 
 	// Initialize in reverse order

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,25 @@ services:
     - POSTGRES_PASSWORD=pgbifrost
     ports:
     - 5432:5432
+    networks:
+      - net
+
+  bifrost:
+    container_name: bifrost
+    image: pg-bifrost:fastest
+    depends_on:
+      - postgres
+    ports:
+      - 6060:6060
+    environment:
+      - BATCH_FLUSH_MAX_AGE=120000
+      - BATCH_FLUSH_UPDATE_AGE=1000
+      - NO_MARSHAL_OLD_VALUE=true
+      - WORKERS=1
+      - BATCHER_MEMORY_SOFT_LIMIT=104857600
+    networks:
+      - net
+    command: /pg-bifrost --host postgres --password pgbifrost replicate -s stdout
+
+networks:
+  net:

--- a/marshaller/marshaller.go
+++ b/marshaller/marshaller.go
@@ -109,7 +109,7 @@ func New(shutdownHandler shutdown.ShutdownHandler,
 	statsChan chan stats.Stat,
 	noMarshalOldValue bool) Marshaller {
 
-	outputChan := make(chan *MarshalledMessage, 1000)
+	outputChan := make(chan *MarshalledMessage)
 
 	return Marshaller{shutdownHandler, inputChan, outputChan, statsChan, noMarshalOldValue}
 }

--- a/transport/batcher/batcher.go
+++ b/transport/batcher/batcher.go
@@ -366,12 +366,14 @@ func (b *Batcher) handleTicker() bool {
 func (b *Batcher) sendBatch(batch transport.Batch) bool {
 
 	// First flush out seen list
-	select {
-	case b.txnsSeenChan <- b.seenList:
-		b.seenList = []*progress.Seen{}
-		log.Debug("seen a BatchTransaction")
-	case <-time.After(b.txnsSeenTimeout):
-		log.Panic("fatal time out sending a BatchTransaction to the ProgressTracker")
+	if len(b.seenList) > 0 {
+		select {
+		case b.txnsSeenChan <- b.seenList:
+			b.seenList = []*progress.Seen{}
+			log.Debug("seen a BatchTransaction")
+		case <-time.After(b.txnsSeenTimeout):
+			log.Panic("fatal time out sending a BatchTransaction to the ProgressTracker")
+		}
 	}
 
 	ok, err := batch.Close()

--- a/transport/factory/factory.go
+++ b/transport/factory/factory.go
@@ -35,7 +35,7 @@ func NewTransport(shutdownHandler shutdown.ShutdownHandler,
 	transportType transport.TransportType,
 	transportConfig map[string]interface{},
 	inputChan <-chan *marshaller.MarshalledMessage,
-	txnsSeen chan<- *progress.Seen,
+	txnsSeen chan<- []*progress.Seen,
 	txnsWritten chan<- *ordered_map.OrderedMap, // Map of <transaction:progress.Written>
 	statsChan chan stats.Stat,
 	workers int,

--- a/transport/manager/manager.go
+++ b/transport/manager/manager.go
@@ -27,7 +27,7 @@ import (
 
 type TransportManager struct {
 	inputChan   <-chan *marshaller.MarshalledMessage
-	txnsSeen    chan *progress.Seen
+	txnsSeen    chan []*progress.Seen
 	txnsWritten chan *ordered_map.OrderedMap
 	statsChan   chan stats.Stat
 
@@ -43,7 +43,7 @@ type TransportManager struct {
 // returns a TransportManager which can start the Batcher and Transporters as go routines.
 func New(shutdownHandler shutdown.ShutdownHandler,
 	inputChan <-chan *marshaller.MarshalledMessage,
-	txnsSeen chan *progress.Seen,
+	txnsSeen chan []*progress.Seen,
 	txnsWritten chan *ordered_map.OrderedMap, // Map of <transaction:progress.Written>
 	statsChan chan stats.Stat,
 	transportType transport.TransportType,

--- a/transport/progress/progress_tracker_test.go
+++ b/transport/progress/progress_tracker_test.go
@@ -37,7 +37,7 @@ func init() {
 type testCase struct {
 	action     string
 	writtenMap *ordered_map.OrderedMap
-	seen       *Seen
+	seen       []*Seen
 }
 
 type testExpected struct {
@@ -79,8 +79,8 @@ func compareLedger(a Ledger, b Ledger) bool {
 	return true
 }
 
-func getProgressTracker() (ProgressTracker, chan *Seen, chan *ordered_map.OrderedMap) {
-	seen := make(chan *Seen)
+func getProgressTracker() (ProgressTracker, chan []*Seen, chan *ordered_map.OrderedMap) {
+	seen := make(chan []*Seen)
 	written := make(chan *ordered_map.OrderedMap, 1000)
 	sh := shutdown.NewShutdownHandler()
 	statsChan := make(chan stats.Stat, 100)
@@ -153,7 +153,7 @@ func TestSingleSeenEntry(t *testing.T) {
 	omap.Set("1-1", &LedgerEntry{"1", "1-1", uint64(111), 0, 1})
 
 	cases := []testCase{
-		testCase{"seen", nil, &Seen{"1", "1-1", 1, 111}},
+		testCase{"seen", nil, []*Seen{{"1", "1-1", 1, 111}}},
 	}
 	entries := []testExpected{
 		testExpected{"1", "1-1", 111, 0, 1},
@@ -188,8 +188,8 @@ func TestSingleSeenEntry(t *testing.T) {
 
 func TestTwoDistinctSeenEntry(t *testing.T) {
 	cases := []testCase{
-		testCase{"seen", nil, &Seen{"1", "1-1", 1, 111}},
-		testCase{"seen", nil, &Seen{"2", "2-1", 1, 222}},
+		testCase{"seen", nil, []*Seen{{"1", "1-1", 1, 111}}},
+		testCase{"seen", nil, []*Seen{{"2", "2-1", 1, 222}}},
 	}
 	entries := []testExpected{
 		testExpected{"1", "1-1", 111, 0, 1},
@@ -207,7 +207,7 @@ func TestSingleSeenAndWrittenEntryWithoutTicker(t *testing.T) {
 	omap2.Set("1-1", &Written{"1", "1-1", 1})
 
 	cases := []testCase{
-		testCase{"seen", nil, &Seen{"1", "1-1", 1, 111}},
+		testCase{"seen", nil, []*Seen{{"1", "1-1", 1, 111}}},
 		testCase{"written", omap2, nil},
 	}
 
@@ -226,7 +226,7 @@ func TestSingleSeenAndWrittenEmitted(t *testing.T) {
 	omap2.Set("1-1", &Written{"1", "1-1", 1})
 
 	cases := []testCase{
-		testCase{"seen", nil, &Seen{"1", "1-1", 1, 999}},
+		testCase{"seen", nil, []*Seen{{"1", "1-1", 1, 999}}},
 		testCase{"written", omap2, nil},
 	}
 
@@ -249,8 +249,8 @@ func TestMultipleSeenAndWrittenEmitted(t *testing.T) {
 	omap4.Set("1-1", &Written{"1", "1-1", 2})
 
 	cases := []testCase{
-		testCase{"seen", nil, &Seen{"1", "1-1", 5, 888}},
-		testCase{"seen", nil, &Seen{"2", "2-1", 2, 999}},
+		testCase{"seen", nil, []*Seen{{"1", "1-1", 5, 888}}},
+		testCase{"seen", nil, []*Seen{{"2", "2-1", 2, 999}}},
 		testCase{"written", omap1, nil},
 		testCase{"written", omap2, nil},
 		testCase{"written", omap3, nil},
@@ -269,8 +269,8 @@ func TestMultipleSeenAndWrittenEmitted(t *testing.T) {
 
 func TestSeenAndSeenAgain(t *testing.T) {
 	cases := []testCase{
-		testCase{"seen", nil, &Seen{"1", "1-1", 1, 999}},
-		testCase{"seen", nil, &Seen{"1", "1-2", 1, 999}},
+		testCase{"seen", nil, []*Seen{{"1", "1-1", 1, 999}}},
+		testCase{"seen", nil, []*Seen{{"1", "1-2", 1, 999}}},
 	}
 	entries := []testExpected{
 		testExpected{"1", "1-2", 999, 0, 1},
@@ -296,10 +296,10 @@ func TestSeenAndSeenAgainThenWritten(t *testing.T) {
 	omap4.Set("1-2", &Written{"1", "1-2", 3})
 
 	cases := []testCase{
-		testCase{"seen", nil, &Seen{"1", "1-1", 10, 999}},
+		testCase{"seen", nil, []*Seen{{"1", "1-1", 10, 999}}},
 		testCase{"written", omap1, nil},
 
-		testCase{"seen", nil, &Seen{"1", "1-2", 10, 999}},
+		testCase{"seen", nil, []*Seen{{"1", "1-2", 10, 999}}},
 		testCase{"written", omap2, nil},
 		testCase{"written", omap3, nil},
 		testCase{"written", omap4, nil},


### PR DESCRIPTION
Originally txn seen progress was sent to the progress tracker via an unbuffered channel every time we saw a `commit` message. The use of the unbuffered channel ensured we always recorded seen txns before written txns. However, this creates a bottleneck in high throughput configurations.

The change I'm making keeps the end functionality the same but instead of reporting seen txns ever time we only report progress right before flushing a batch to the transporters. By batching up the progress we avoid the overhead of frequent synchronization between batcher and progress tracker.