### PR TITLE
fix servertime bug

### DIFF
--- a/replication/message.go
+++ b/replication/message.go
@@ -53,7 +53,7 @@ func XLogDataToWalMessage(xld pglogrepl.XLogData) (*WalMessage, error) {
 		uint64(xld.WALStart),
 		uint64(xld.ServerWALEnd),
 		// Note that in current postgres versions (9,10,11) ServerTime is unset and comes through as 0
-		int64(xld.ServerTime.Second()),
+		xld.ServerTime.UnixMilli(),
 		"",
 		pr,
 		"",


### PR DESCRIPTION
Previously the servertime of a replicated message was not transmitted in older versions of postgres. When we upgraded to a newer version we didn't bother checking if it worked. It does, but we had 2 bugs here 1) we used `Seconds()` which provides the second component of the timestamp (0-59) versus the posix time. 2) the conversion function later on expected time in milliseconds instead of seconds so this would have been broken anyway.